### PR TITLE
impl(pubsub): subscriber with tracing quickstart

### DIFF
--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
@@ -51,6 +51,8 @@ class TracingPullLeaseManager : public PullLeaseManager {
   future<Status> ExtendLease(std::shared_ptr<SubscriberStub> stub,
                              std::chrono::system_clock::time_point time_now,
                              std::chrono::seconds extension) override {
+    auto span2 = internal::MakeSpan("test span");
+    span2->End();
     namespace sc = opentelemetry::trace::SemanticConventions;
     opentelemetry::trace::StartSpanOptions options;
     options.kind = opentelemetry::trace::SpanKind::kClient;

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
@@ -42,7 +42,11 @@ class TracingPullLeaseManager : public PullLeaseManager {
                 opentelemetry::context::RuntimeContext::GetCurrent())
                 ->GetContext()) {}
 
-  void StartLeaseLoop() override { child_->StartLeaseLoop(); };
+  void StartLeaseLoop() override {
+    std::cerr << "ALEVENB"
+              << "StartLeaseLoopn\n";
+    child_->StartLeaseLoop();
+  };
 
   std::chrono::milliseconds LeaseRefreshPeriod() const override {
     return child_->LeaseRefreshPeriod();
@@ -56,6 +60,8 @@ class TracingPullLeaseManager : public PullLeaseManager {
     namespace sc = opentelemetry::trace::SemanticConventions;
     opentelemetry::trace::StartSpanOptions options;
     options.kind = opentelemetry::trace::SpanKind::kClient;
+    std::cerr << "ALEVENB"
+              << "make mod ack span\n";
     auto span = internal::MakeSpan(
         child_->subscription().subscription_id() + " modack",
         {{sc::kMessagingSystem, "gcp_pubsub"},

--- a/google/cloud/pubsub/quickstart/BUILD.bazel
+++ b/google/cloud/pubsub/quickstart/BUILD.bazel
@@ -143,6 +143,18 @@ cc_binary(
 
 
 cc_binary(
+    name = "modack",
+    srcs = [
+        "modack.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
     name = "nothing",
     srcs = [
         "nothing.cc",

--- a/google/cloud/pubsub/quickstart/BUILD.bazel
+++ b/google/cloud/pubsub/quickstart/BUILD.bazel
@@ -17,11 +17,12 @@ package(default_visibility = ["//visibility:private"])
 licenses(["notice"])  # Apache 2.0
 
 cc_binary(
-    name = "quickstart",
+    name = "subscriber_quickstart_timer",
     srcs = [
-        "quickstart.cc",
+        "subscriber_quickstart_timer.cc",
     ],
     deps = [
+        "@google_cloud_cpp//:opentelemetry",
         "@google_cloud_cpp//:pubsub",
     ],
 )
@@ -32,6 +33,143 @@ cc_binary(
         "subscriber_quickstart.cc",
     ],
     deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
+    name = "subscriber_fc_quickstart",
+    srcs = [
+        "subscriber_fc_quickstart.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
+    name = "subscriber_ordering_quickstart",
+    srcs = [
+        "subscriber_ordering_quickstart.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
+    name = "subscriber_concurrency_quickstart",
+    srcs = [
+        "subscriber_concurrency_quickstart.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+cc_binary(
+    name = "subscriber_pull_quickstart",
+    srcs = [
+        "subscriber_pull_quickstart.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+cc_binary(
+    name = "quickstart",
+    srcs = [
+        "quickstart.cc",
+    ],
+    deps = [
+        "//:common",
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+cc_binary(
+    name = "clean",
+    srcs = [
+        "clean.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+cc_binary(
+    name = "subscriber_ack",
+    srcs = [
+        "subscriber_ack.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
+    name = "nack",
+    srcs = [
+        "nack.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+cc_binary(
+    name = "expire",
+    srcs = [
+        "expire.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+
+cc_binary(
+    name = "nothing",
+    srcs = [
+        "nothing.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+cc_binary(
+    name = "exactly",
+    srcs = [
+        "exactly.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
+        "@google_cloud_cpp//:pubsub",
+    ],
+)
+
+cc_binary(
+    name = "alex",
+    srcs = [
+        "alex.cc",
+    ],
+    deps = [
+        "@google_cloud_cpp//:opentelemetry",
         "@google_cloud_cpp//:pubsub",
     ],
 )

--- a/google/cloud/pubsub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsub/quickstart/WORKSPACE.bazel
@@ -23,31 +23,29 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
     name = "google_cloud_cpp",
-    sha256 = "ce18fbd3a50170fb0c3d4cacf8a09136314f00136cdac99dad23b43de5d5bb62",
-    strip_prefix = "google-cloud-cpp-2.23.0",
-    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.23.0.tar.gz",
+    sha256 = "63f009092afd900cb812050bcecf607e37d762ac911e0bcbf4af9a432da91890",
+    strip_prefix = "google-cloud-cpp-2.19.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.19.0.tar.gz",
 )
 
-load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
-gl_cpp_workspace0()
+google_cloud_cpp_deps()
 
-load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
-gl_cpp_workspace1()
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
 
-load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
-gl_cpp_workspace2()
+grpc_deps()
 
-load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
-gl_cpp_workspace3()
-
-load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
-
-gl_cpp_workspace4()
-
-load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
-
-gl_cpp_workspace5()
+grpc_extra_deps()

--- a/google/cloud/pubsub/quickstart/alex.cc
+++ b/google/cloud/pubsub/quickstart/alex.cc
@@ -1,0 +1,99 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:alex
+// gcloud pubsub topics create alex-topic
+// gcloud pubsub subscriptions create alex-sub --topic=alex-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "alex-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)));
+  std::string const topic_id = "alex-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 1;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::unordered_map<std::string, uint32_t> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(1);
+        if (messages.count(m.message_id()) == 2) {
+          std::move(h).ack();
+        } else {
+          messages[m.message_id()] += 1;
+        }
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/clean.cc
+++ b/google/cloud/pubsub/quickstart/clean.cc
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include <iostream>
+
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "alex-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(10);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id)));
+
+  // Ack all messages on a sub.
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << "Received message " << m << "\n";
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/exactly.cc
+++ b/google/cloud/pubsub/quickstart/exactly.cc
@@ -1,0 +1,100 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:nack
+// gcloud pubsub topics create exactly-topic
+// gcloud pubsub subscriptions create exactly-sub --topic=exactly-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "exactly-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(180);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(10))));
+  std::string const topic_id = "exactly-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 1;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::unordered_set<std::string> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(60);
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+  // Pull message so it doesn't wait forever
+  auto response = subscriber.Pull();
+  std::cout << "Received message " << response->message << "\n";
+  std::move(response->handler).ack();
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/expire.cc
+++ b/google/cloud/pubsub/quickstart/expire.cc
@@ -1,0 +1,104 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:nack
+// gcloud pubsub topics create expire-topic
+// gcloud pubsub subscriptions create expire-sub --topic=expire-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "expire-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(60);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(60))));
+  std::string const topic_id = "expire-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 1;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::unordered_set<std::string> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(41);
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+   session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << "Received message " << m << "\n";
+        std::move(h).ack();
+      });
+
+  // Blocks until the timeout is reached.
+   result = session.wait_for(std::chrono::seconds(10));
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/modack.cc
+++ b/google/cloud/pubsub/quickstart/modack.cc
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) try {
   std::string const subscription_id = "modack-sub";
   std::string const topic_id = "modack-topic";
 
-  auto constexpr kWaitTimeout = std::chrono::seconds(180);
+  auto constexpr kWaitTimeout = std::chrono::seconds(60);
 
   // Create a namespace alias to make the code easier to read.
   namespace pubsub = ::google::cloud::pubsub;
@@ -45,8 +45,9 @@ int main(int argc, char* argv[]) try {
       pubsub::Subscription(project_id, subscription_id),
       gc::Options{}
           .set<gc::OpenTelemetryTracingOption>(true)
-          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(5))
-          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(5))));
+          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineTimeOption>(std::chrono::seconds(60))));
   auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
       pubsub::Topic(project_id, topic_id),
       gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
@@ -79,11 +80,6 @@ int main(int argc, char* argv[]) try {
         std::cout << m.data() << ". ";
         std::cout << "Received message with id: (" << m.message_id() << ")\n";
         sleep(10);
-        if (i ==0) {
-            std::move(h).ack();
-            i++;
-        }
-
       });
 
   std::cout << "Waiting for messages on " + subscription_id + "...\n";

--- a/google/cloud/pubsub/quickstart/modack.cc
+++ b/google/cloud/pubsub/quickstart/modack.cc
@@ -1,0 +1,106 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:modack
+// gcloud pubsub topics create modack-topic
+// gcloud pubsub subscriptions create modack-sub --topic=modack-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "modack-sub";
+  std::string const topic_id = "modack-topic";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(180);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(5))
+          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(5))));
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 10;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::atomic<int> i;
+  std::unordered_set<std::string> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(10);
+        if (i ==0) {
+            std::move(h).ack();
+            i++;
+        }
+
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+  // Pull message so it doesn't wait forever
+  auto response = subscriber.Pull();
+  std::cout << "Received message " << response->message << "\n";
+  std::move(response->handler).ack();
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/nack.cc
+++ b/google/cloud/pubsub/quickstart/nack.cc
@@ -1,0 +1,100 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:nack
+// gcloud pubsub topics create nack-topic
+// gcloud pubsub subscriptions create nack-sub --topic=nack-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "nack-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)));
+  std::string const topic_id = "nack-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 1;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::unordered_set<std::string> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(2);
+        if (messages.count(m.message_id())) {
+          std::move(h).ack();
+        } else {
+          messages.insert(m.message_id());
+          std::move(h).nack();
+        }
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/nothing.cc
+++ b/google/cloud/pubsub/quickstart/nothing.cc
@@ -1,0 +1,98 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:nack
+// gcloud pubsub topics create nothing-topic
+// gcloud pubsub subscriptions create nothing-sub --topic=nothing-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "nothing-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(180);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)));
+  std::string const topic_id = "nothing-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 10;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  std::unordered_set<std::string> messages;
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(2);
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+  // Pull message so it doesn't wait forever
+  auto response = subscriber.Pull();
+  std::cout << "Received message " << response->message << "\n";
+  std::move(response->handler).ack();
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/quickstart.cc
+++ b/google/cloud/pubsub/quickstart/quickstart.cc
@@ -13,29 +13,48 @@
 // limitations under the License.
 
 //! [START pubsub_quickstart_publisher] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
 #include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/opentelemetry_options.h"
 #include <iostream>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " <project-id> <topic-id>\n";
-    return 1;
-  }
-
-  std::string const project_id = argv[1];
-  std::string const topic_id = argv[2];
+  std::string const project_id = "alevenb-test";
+  std::string const topic_id = "my-topic";
 
   // Create a namespace alias to make the code easier to read.
   namespace pubsub = ::google::cloud::pubsub;
+  namespace gc = ::google::cloud;
+  namespace otel = ::google::cloud::otel;
 
-  auto publisher = pubsub::Publisher(
-      pubsub::MakePublisherConnection(pubsub::Topic(project_id, topic_id)));
-  auto id =
-      publisher
-          .Publish(pubsub::MessageBuilder{}.SetData("Hello World!").Build())
-          .get();
-  if (!id) throw std::move(id).status();
-  std::cout << "Hello World published with id=" << *id << "\n";
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(false);
+  // .set<pubsub::MaxBatchMessagesOption>(1000)
+  // .set<pubsub::MaxHoldTimeOption>(std::chrono::seconds(1));
+
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id), options));
+
+  int n = 10;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id = publisher.Publish(pubsub::MessageBuilder().SetData("Hi!").Build())
+                  .then([](gc::future<gc::StatusOr<std::string>> f) {
+                    auto status = f.get();
+                    if (!status) {
+                      std::cout << "Error in publish: " << status.status()
+                                << "\n";
+                      return;
+                    }
+                    std::cout << "Sent message with id: (" << *status << ")\n";
+                  });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
 
   return 0;
 } catch (google::cloud::Status const& status) {

--- a/google/cloud/pubsub/quickstart/subscriber_ack.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_ack.cc
@@ -1,0 +1,97 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subscriber_ack
+// gcloud pubsub topics create ack
+// gcloud pubsub subscriptions create ack-sub --topic=ack
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "ack-sub1";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id), options));
+  std::string const topic_id = "ack-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 6;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(pubsub::MessageBuilder()
+                         .SetData(std::to_string(i))
+                         .Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status
+                        << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id()
+                  << ")\n";
+        sleep(2);
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/subscriber_concurrency_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_concurrency_quickstart.cc
@@ -1,0 +1,95 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subsciber_concurrency_quickstart
+// gcloud pubsub topics create cc-topic
+// gcloud pubsub subscriptions create cc-sub --topic=cc-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "cc-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MaxConcurrencyOption>(2)));
+  std::string const topic_id = "cc-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 6;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(2);
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/subscriber_fc_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_fc_quickstart.cc
@@ -1,0 +1,95 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subsciber_fc_quickstart
+// gcloud pubsub topics create flow-control-topic
+// gcloud pubsub subscriptions create flow-control-sub --topic=flow-control-topic
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "flow-control-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MaxOutstandingMessagesOption>(2)));
+  std::string const topic_id = "flow-control-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 6;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id =
+        publisher
+            .Publish(
+                pubsub::MessageBuilder().SetData(std::to_string(i)).Build())
+            .then([index = i](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id() << ")\n";
+        sleep(2);
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/subscriber_ordering_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_ordering_quickstart.cc
@@ -1,0 +1,98 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subscriber_quickstart
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "orderd-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id), options));
+  std::string const topic_id = "orderd-topic";
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}
+          .set<gc::OpenTelemetryTracingOption>(true)
+          .set<pubsub::MessageOrderingOption>(true)));
+
+  int n = 6;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    std::string ordering_key = (i % 2 == 0 ? "a" : "b");
+    auto id =
+        publisher
+            .Publish(pubsub::MessageBuilder()
+                         .SetData(std::to_string(i))
+                         .SetOrderingKey(ordering_key)
+                         .Build())
+            .then([index = i, key =ordering_key](gc::future<gc::StatusOr<std::string>> f) {
+              auto status = f.get();
+              if (!status) {
+                std::cout << "Error in publish: " << status.status() << "\n";
+                return;
+              }
+              std::cout << index << ". ";
+              std::cout << "Sent message with id: (" << *status
+                        << ") and ordering key (" << key << ")\n";
+            });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << m.data() << ". ";
+        std::cout << "Received message with id: (" << m.message_id()
+                  << ") and ordering key (" << m.ordering_key() << ")\n";
+        sleep(2);
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
@@ -34,7 +34,12 @@ int main(int argc, char* argv[]) try {
   auto configuration = otel::ConfigureBasicTracing(project);
 
   // Create a client with OpenTelemetry tracing enabled.
-  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
+  auto options =
+      gc::Options{}
+          .set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(10))
+          .set<pubsub::MaxDeadlineTimeOption>(std::chrono::seconds(60))
+          .set<gc::OpenTelemetryTracingOption>(true);
 
   auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
       pubsub::Subscription(project_id, subscription_id), options));
@@ -43,6 +48,7 @@ int main(int argc, char* argv[]) try {
   while (response) {
     std::cout << "acking\n";
     std::cout << "Received message " << response->message << "\n";
+    sleep(20);
     std::move(response->handler).ack();
     response = subscriber.Pull();
   }

--- a/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subscriber_pull_quickstart
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "my-sub";
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
+
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id), options));
+
+  auto response = subscriber.Pull();
+  while (response) {
+    std::cout << "acking\n";
+    std::cout << "Received message " << response->message << "\n";
+    std::move(response->handler).ack();
+    response = subscriber.Pull();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]

--- a/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_pull_quickstart.cc
@@ -15,14 +15,19 @@
 //! [START pubsub_quickstart_subscriber] [all]
 #include "google/cloud/opentelemetry/configure_basic_tracing.h"
 #include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/publisher.h"
 #include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/pubsub/topic.h"
 #include "google/cloud/opentelemetry_options.h"
 #include <iostream>
 
 // bazel run //google/cloud/pubsub/quickstart:subscriber_pull_quickstart
+// gcloud pubsub topics create pull-quick-topic
+// gcloud pubsub subscriptions create pull-quick-sub --topic=pull-quick-topic
 int main(int argc, char* argv[]) try {
   std::string const project_id = "alevenb-test";
-  std::string const subscription_id = "my-sub";
+  std::string const subscription_id = "pull-quick-sub";
+  std::string const topic_id = "pull-quick-topic";
 
   // Create a namespace alias to make the code easier to read.
   namespace pubsub = ::google::cloud::pubsub;
@@ -41,6 +46,20 @@ int main(int argc, char* argv[]) try {
           .set<pubsub::MaxDeadlineTimeOption>(std::chrono::seconds(60))
           .set<gc::OpenTelemetryTracingOption>(true);
 
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id), options));
+
+  auto id = publisher.Publish(pubsub::MessageBuilder().SetData("Hi!").Build())
+                .then([](gc::future<gc::StatusOr<std::string>> f) {
+                  auto status = f.get();
+                  if (!status) {
+                    std::cout << "Error in publish: " << status.status()
+                              << "\n";
+                    return;
+                  }
+                  std::cout << "Sent message with id: (" << *status << ")\n";
+                });
+
   auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
       pubsub::Subscription(project_id, subscription_id), options));
 
@@ -48,7 +67,7 @@ int main(int argc, char* argv[]) try {
   while (response) {
     std::cout << "acking\n";
     std::cout << "Received message " << response->message << "\n";
-    sleep(20);
+    // sleep(20);
     std::move(response->handler).ack();
     response = subscriber.Pull();
   }

--- a/google/cloud/pubsub/quickstart/subscriber_quickstart_timer.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_quickstart_timer.cc
@@ -39,14 +39,15 @@ int main(int argc, char* argv[]) try {
 
   // Create a client with OpenTelemetry tracing enabled.
   auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
-  options.set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(1));
-  options.set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(3));
- // lease management options
+  options.set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(10));
+  options.set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(10));
+  // lease management options
   options.set<pubsub::MaxOutstandingMessagesOption>(2);
+  options.set<pubsub::MaxDeadlineTimeOption>(std::chrono::seconds(60));
   // options.set<pubsub::MaxOutstandingBytesOption>(8 * kMiB);
-          // Concurrency
-          //  options .set<pubsub::MaxConcurrencyOption>(8);
-          //  options .set<GrpcBackgroundThreadPoolSizeOption>(16);
+  // Concurrency
+  //  options .set<pubsub::MaxConcurrencyOption>(8);
+  //  options .set<GrpcBackgroundThreadPoolSizeOption>(16);
   auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
       pubsub::Subscription(project_id, subscription_id), options));
 
@@ -96,6 +97,7 @@ int main(int argc, char* argv[]) try {
         //                 << "\n";
         //   std::cout << attribute_msg.str();
         // }
+        sleep(10);
         // std::move(h).nack();
         std::move(h).ack();
       });

--- a/google/cloud/pubsub/quickstart/subscriber_quickstart_timer.cc
+++ b/google/cloud/pubsub/quickstart/subscriber_quickstart_timer.cc
@@ -1,0 +1,133 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [START pubsub_quickstart_subscriber] [all]
+#include "google/cloud/opentelemetry/configure_basic_tracing.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/opentelemetry_options.h"
+#include <iostream>
+
+// bazel run //google/cloud/pubsub/quickstart:subscriber_quickstart
+int main(int argc, char* argv[]) try {
+  std::string const project_id = "alevenb-test";
+  std::string const subscription_id = "my-sub";
+
+  auto constexpr kWaitTimeout = std::chrono::seconds(30);
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub = ::google::cloud::pubsub;
+  namespace otel = ::google::cloud::otel;
+  namespace experimental = ::google::cloud::experimental;
+  namespace gc = ::google::cloud;
+
+  auto project = gc::Project(project_id);
+  auto configuration = otel::ConfigureBasicTracing(project);
+
+  // Create a client with OpenTelemetry tracing enabled.
+  auto options = gc::Options{}.set<gc::OpenTelemetryTracingOption>(true);
+  options.set<pubsub::MinDeadlineExtensionOption>(std::chrono::seconds(1));
+  options.set<pubsub::MaxDeadlineExtensionOption>(std::chrono::seconds(3));
+ // lease management options
+  options.set<pubsub::MaxOutstandingMessagesOption>(2);
+  // options.set<pubsub::MaxOutstandingBytesOption>(8 * kMiB);
+          // Concurrency
+          //  options .set<pubsub::MaxConcurrencyOption>(8);
+          //  options .set<GrpcBackgroundThreadPoolSizeOption>(16);
+  auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+      pubsub::Subscription(project_id, subscription_id), options));
+
+  // auto message = subscriber.Pull()
+  // auto response = subscriber.Pull();
+  // if (!response) throw std::move(response).status();
+  // std::cout << "Received message " << response->message << "\n";
+  // std::move(response->handler).ack();
+
+  std::string const topic_id = "my-topic";
+
+  // Create a client with OpenTelemetry tracing enabled.
+  // .set<pubsub::MaxBatchMessagesOption>(1000)
+  // .set<pubsub::MaxHoldTimeOption>(std::chrono::seconds(1));
+
+  auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+      pubsub::Topic(project_id, topic_id),
+      gc::Options{}.set<gc::OpenTelemetryTracingOption>(true)));
+
+  int n = 1000;
+  std::vector<gc::future<void>> ids;
+  for (int i = 0; i < n; i++) {
+    auto id = publisher.Publish(pubsub::MessageBuilder().SetData("Hi!").Build())
+                  .then([](gc::future<gc::StatusOr<std::string>> f) {
+                    auto status = f.get();
+                    if (!status) {
+                      std::cout << "Error in publish: " << status.status()
+                                << "\n";
+                      return;
+                    }
+                    std::cout << "Sent message with id: (" << *status << ")\n";
+                  });
+    ids.push_back(std::move(id));
+  }
+  // Block until they are actually sent.
+  for (auto& id : ids) id.get();
+
+  auto session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        // std::stringstream msg;
+        msg << "Received message " << m
+            << "with attributes: " << m.attributes().size() << "\n";
+        // std::cout << msg.str();
+        // for (const auto& item : m.attributes()) {
+        //   std::stringstream attribute_msg;
+        //   attribute_msg << "Key: " << item.first << "Value: " << item.second
+        //                 << "\n";
+        //   std::cout << attribute_msg.str();
+        // }
+        // std::move(h).nack();
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+
+  // session.wait();
+  // Blocks until the timeout is reached.
+  auto result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+  session.get();
+  session =
+      subscriber.Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+        std::cout << "Received message " << m << "\n";
+        std::move(h).ack();
+      });
+
+  std::cout << "Waiting for messages on " + subscription_id + "...\n";
+
+  // Blocks until the timeout is reached.
+  result = session.wait_for(kWaitTimeout);
+  if (result == std::future_status::timeout) {
+    std::cout << "timeout reached, ending session\n";
+    session.cancel();
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}
+//! [END pubsub_quickstart_subscriber] [all]


### PR DESCRIPTION
bazel run //google/cloud/pubsub/quickstart:expire alevenb-test expire-sub

gcloud pubsub topics create expire-topic
gcloud pubsub subscriptions create expire-sub --topic=expire-topic


